### PR TITLE
Use Babel to create ES5 build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "plugins": ["transform-es2015-modules-commonjs"]
-}

--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": "entry"
+      }
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -30,13 +30,15 @@
     "testEnvironment": "node"
   },
   "devDependencies": {
-    "babel-jest": "^19.0.0",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "eslint": "^3.19.0",
     "eslint-config-cheminfo": "^1.7.0",
     "eslint-plugin-no-only-tests": "^1.1.0",
     "jest": "^19.0.2",
     "npm-run-all": "^4.0.2",
-    "rollup": "^1.1.2"
+    "rollup": "^1.1.2",
+    "rollup-plugin-babel": "^4.3.2"
+  },
+  "dependencies": {
+    "@babel/core": "^7.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "testEnvironment": "node"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.3.1",
     "eslint": "^3.19.0",
     "eslint-config-cheminfo": "^1.7.0",
     "eslint-plugin-no-only-tests": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "eslint": "eslint src",
     "eslint-fix": "npm run eslint -- --fix",
-    "prepublish": "rollup -c",
+    "prepare": "rollup -c",
     "test": "run-s testonly eslint",
     "testonly": "jest"
   },
@@ -37,6 +37,6 @@
     "eslint-plugin-no-only-tests": "^1.1.0",
     "jest": "^19.0.2",
     "npm-run-all": "^4.0.2",
-    "rollup": "^0.41.6"
+    "rollup": "^1.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,8 @@
   "version": "1.2.0",
   "description": "Base class for regression modules",
   "main": "lib/index.js",
-  "module": "src/index.js",
   "files": [
-    "lib",
-    "src"
+    "lib"
   ],
   "scripts": {
     "eslint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "testEnvironment": "node"
   },
   "devDependencies": {
+    "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.3.1",
     "eslint": "^3.19.0",
     "eslint-config-cheminfo": "^1.7.0",
@@ -38,8 +39,5 @@
     "npm-run-all": "^4.0.2",
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2"
-  },
-  "dependencies": {
-    "@babel/core": "^7.2.2"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import babel from 'rollup-plugin-babel';
 
 export default {
   input: 'src/index.js',
@@ -6,5 +7,10 @@ export default {
     format: 'cjs',
     exports: 'named'
   },
+  plugins: [
+    babel({
+      exclude: 'node_modules/**'
+    })
+  ]
 };
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,10 @@
+
 export default {
-    entry: 'src/index.js',
+  input: 'src/index.js',
+  output: {
+    file: 'lib/index.js',
     format: 'cjs',
-    dest: 'lib/index.js',
     exports: 'named'
+  },
 };
+


### PR DESCRIPTION
This allows the built library to be used in projects which need to support IE11. I appreciate that you may not wish to make this change to your project.